### PR TITLE
disable no-else-return and no-param-reassign

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,5 +9,6 @@ module.exports = {
     'react/prefer-stateless-function': 0,
     'react/sort-comp': 0,
     'semi': [2, 'never'],
+    "no-param-reassign": ["error", { "props": false }],
   },
 };


### PR DESCRIPTION
@ajgrover @ryngonzalez 

There are some valid use cases for `no-param-reassign`:

```
function onChange(domEvt) {
  domEvt.target.value = transform(domEvt.target.value)
}
```

partially disabled for now, and we can revisit if we find a better way to do this
