### PR TITLE
alter no-unused-vars rule according to group discussion

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = {
     'import/no-unresolved': 0,
     'max-len': 0,
     'no-underscore-dangle': [2, { 'allowAfterThis': true }],
+    'no-unused-vars': ["error", { "vars": "all", "args": "none" }],
     'react/prefer-stateless-function': 0,
     'react/sort-comp': 0,
     'semi': [2, 'never'],


### PR DESCRIPTION
In theory this should allow the rule to remain for any variables declared, but ignore it pertaining to any that come in as arguments.

@ajgrover 
