### PR TITLE
disable jsx-no-bind

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,5 +11,6 @@ module.exports = {
     'react/sort-comp': 0,
     'semi': [2, 'never'],
     "no-param-reassign": ["error", { "props": false }],
+    "react/jsx-no-bind": 0,
   },
 };


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

i don't disagree with this rule at all, but it's purely a performance thing. i think once we get to the point where we can afford to focus on performance (right now we just need better architecture + reliability) then we can re-enable this

@ajgrover @ryngonzalez what do you guys think?
