### PR TITLE
allow param reassign

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ module.exports = {
     'react/prefer-stateless-function': 0,
     'react/sort-comp': 0,
     'semi': [2, 'never'],
-    "no-param-reassign": ["error", { "props": false }],
+    "no-param-reassign": 0,
     "react/jsx-no-bind": 0,
   },
 };


### PR DESCRIPTION
it seems like there's a lot of valid code that can't pass this rule

```
function foo(bar) {
  if (bar === null) {
     bar = getDefaultBar();
  } 
}
```

it also seems like the main argument for this is unintended behavior from changing the `arguments`, but i dont think it's a big deal for us (see https://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/)
