### PR TITLE
Error on unused args

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
     'max-len': 0,
     'no-param-reassign': 0,
     'no-underscore-dangle': [2, { 'allowAfterThis': true }],
-    'no-unused-vars': ['error', { 'vars': 'all', 'args': 'none' }],
+    'no-unused-vars': ["error", { "vars": "all", "args": "after-used" }],
     'react/jsx-no-bind': 0,
     'react/prefer-stateless-function': 0,
     'react/sort-comp': 0,


### PR DESCRIPTION
### Why it's useful

it's immediately obvious (to some extent) what a function actually depends on. for example, a lot of our actioncreators right now have thunks like this:

```
return (dispatch, getState) => { ... }
```

even though they don't actually use `getState`. with this rule turned on, it's easy to tell at a glance that whether or not an actioncreator actually depends on the redux state or not.
### The Tradeoff

sometimes it's nice to add arguments to signal that an argument is available for use in the future. e.g. 

```
_onFailure(errorMsg) {
  // doesn't actually use the errorMsg, but at least everyone knows it actually exists
}
```

---

what do you guys think? personally, I'm in favor of turning this on

@ajgrover @ryngonzalez
